### PR TITLE
Twin tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,11 +12,12 @@ Scripting examples and tools for QTM.  Lua and Python are supported in the QTM S
 This repository contains example scripts and useful script based tools for QTM.
 1. Demo Scripts contains example scripts demonstrating various capabilities of the scripting engine.
 2. Tools contains various helpful tools for use in QTM
-    - Gap_Fill has a selection of gap trimming and filling tools using stored relational information based on marker names from the standard Animation markerset
-    - Filter has spike reporting and removal/smoothing tools
-    - Markerset has miscellaneous tools for reporting, modifying and selecting markersets.
-    - Refine rigid bodies can be used to adapt rigid body definitions to measured markers.
-    - Gap fill presets can be used to define and use custom gap fill actions, including relational gap fill.
+    - *GapFill* has a selection of gap trimming and filling tools using stored relational information based on marker names from the standard Animation markerset
+    - *Filter* has spike reporting and removal/smoothing tools
+    - *Markerset* has miscellaneous tools for reporting, modifying and selecting markersets.
+    - *Refine rigid body* can be used to adapt rigid body definitions to measured markers.
+    - *Gap fill presets* can be used to define and use custom gap fill actions, including relational gap fill.
+    - *Twin* contains an alternative twin calibration method using a rigid body (6DOF).
 ## Adding your own script menus
 1. Follow the example of the scripts, such as "gap_fill.py" in the tools folder:
     - Have an exported function to create a menu, call it "add_menu()"

--- a/tools/twin_tools.py
+++ b/tools/twin_tools.py
@@ -178,7 +178,7 @@ def add_menu():
         add_my_commands()
         setup_my_menu()
     else:
-        print(f"You need Numpy installed in Python to use the Refine Rigid Body menu.")
+        print(f"You need Numpy installed in Python to use the Twin menu.")
 
 if __name__ == "__main__":
     add_menu()

--- a/tools/twin_tools.py
+++ b/tools/twin_tools.py
@@ -1,0 +1,169 @@
+"""twin_tools.py: Tools for twin system
+
+General info
+Twin calibration based on rigid bodies with aligned LCS.
+
+Description of menu
+
+Use of the script:
+* Bla
+
+Script variables (global):
+* 
+
+Requirements:
+* numpy
+
+"""
+
+import importlib
+
+import qtm
+
+# import qtm.data.object.trajectory as traj
+# import qtm.data.series._3d as data_3d
+
+import qtm.data.series._6d as data_6d
+import qtm.settings.processing._6d as rb
+
+import qtm.gui.timeline as tline
+import qtm.gui.terminal as trm
+# import qtm.utilities.color as clr
+
+import math
+
+have_numpy = True
+try:
+    import numpy as np
+except:
+    have_numpy = False
+
+
+# Script variables (global)
+# rb_refine_write_mode = "replace" # "replace"/"add": replace points in current rigid body definition, or add new refined rigid body
+# rb_refine_menu_name = "Refine rigid body"
+
+# --- Copied and adapted from qmath.py (from Jeffrey Thingvold)
+# Checked definition in Diebel, J. (2006), Representing attitude
+# Calculates rotation matrix to euler angles (Qualisys standard xyz)
+def rotationMatrixToEulerAngles(R):
+    sy = math.sqrt(R[0,0] * R[0,0] +  R[1,0] * R[1,0])
+    singular = sy < 1e-6
+ 
+    if  not singular :
+        x = math.atan2(R[2,1] , R[2,2]) # roll
+        y = math.atan2(-R[2,0], sy)     # pitch
+        z = math.atan2(R[1,0], R[0,0])  # yaw
+    else :
+        x = math.atan2(-R[1,2], R[1,1])
+        y = math.atan2(-R[2,0], sy)
+        z = 0
+ 
+    return np.array([math.degrees(x), math.degrees(y), math.degrees(z)])
+# ---
+
+def _twin_calib_6dof():
+    """Function for 6dof twin calibration."""
+
+    # For algorithm, see Matlab script under C:\Users\labbuser\Documents\EST\Data\2023-08-25 Twin Oostende
+    
+    # Checks
+    # - Check number of rigid bodies in file
+    try:
+        nrb_file = rb.get_body_count("measurement")
+    except:
+        # logging.error("A file should be open with the same rigid bodies as in the project.")
+        trm.write("A file should be open including two rigid bodies.")
+        return
+    
+    if nrb_file != 2:
+        trm.write("The file must contain two rigid bodies.")
+        return
+    
+    # - Check coordinate system
+    if not(rb.get_body_coordinate_system("measurement", 0)["type"] == "global") or \
+            not(rb.get_body_coordinate_system("measurement", 1)["type"] == "global"):
+        trm.write("Rigid bodies' coordinate systems must be global for this operation.")
+        return
+    
+    # Check Euler convention
+    if not(qtm.settings.euler.get_convention() == "qualisys"):
+        trm.write("Euler convention must be Qualisys standard for this operation.")
+        return
+
+    # Get current frame
+    try:
+        cf = tline.get_current_frame()
+    except: 
+        trm.write("6DOF twin calibration not supported in Preview mode.\nMake a capture and try again.")
+        return
+        
+    # Calculate rotation of rigid body 2 (slave) relative to rigid body 1 (master) at current frame
+    series_id_0 = data_6d.get_series_id(0)
+    RT_0 = np.array(data_6d.get_sample(series_id_0, cf)["transform"])
+    T_0 = RT_0.transpose()[3,0:3]
+
+    series_id_1 = data_6d.get_series_id(1)
+    RT_1 = np.array(data_6d.get_sample(series_id_1, cf)["transform"])
+    T_1 = RT_1.transpose()[3,0:3]
+    # print(f"T_1: {T_1}")
+    
+    R_align = np.matmul(RT_1[0:3,0:3].transpose(), RT_0[0:3,0:3])
+
+    # Rotate rigid body 2 position (align rigid body 2 to rigid body 1)
+    T_aligned = np.matmul(T_1, R_align)
+    # print(f"T_aligned: {T_aligned}")
+
+    # Calculate translation of rigid body 2 (slave after rotation) relative to rigid body 1 (master)
+    D = T_0 - T_aligned
+
+    # Convert rotation to Euler (RPY)
+    RPYs = rotationMatrixToEulerAngles(R_align)
+
+    # Put twin calibration parameters in list
+    twin_params = [D[0], D[1], D[2], \
+            RPYs[0], RPYs[1], RPYs[2]]
+
+    trm.write("Twin calibration parameters (X, Y, Z, Roll, Pitch, Yaw): ")
+    print(twin_params)
+
+    # Applying twin calibration with these parameters does not perfectly align the rigid bodies in selected frame in QTM.
+    # This needs to be investigated
+
+
+def add_my_commands():
+    """Function for adding new commands used in this script to QTM"""
+
+    # Add command for display of script doc string
+    command_name = "disp_twin_tools_doc"
+    qtm.gui.add_command(command_name)
+    qtm.gui.set_command_execute_function(command_name, lambda:(print(__doc__)))
+
+    # Add command for updating the rigid body list for the 
+    qtm.gui.add_command("twin_calib_6dof")
+    qtm.gui.set_command_execute_function("twin_calib_6dof", _twin_calib_6dof)
+
+
+def setup_my_menu():
+    """Function for setting up the menu."""
+    my_menu_id = qtm.gui.insert_menu_submenu(None, "Twin")
+    
+    # Add Help button for display of the script doc string
+    qtm.gui.insert_menu_button(my_menu_id, "Help", "disp_twin_tools_doc")
+    qtm.gui.insert_menu_separator(my_menu_id)
+
+    # Add button for updating Refine rigid body menu items.
+    qtm.gui.insert_menu_button(my_menu_id, "Twin calibration (6DOF)", "twin_calib_6dof")
+
+# menu_priority = 1
+
+def add_menu():
+    if have_numpy:
+        # - Add commanads and set up menu
+        add_my_commands()
+        setup_my_menu()
+    else:
+        print(f"You need Numpy installed in Python to use the Refine Rigid Body menu.")
+
+if __name__ == "__main__":
+    add_menu()

--- a/tools/twin_tools.py
+++ b/tools/twin_tools.py
@@ -12,13 +12,13 @@ This scripts adds a menu "Twin" to QTM the QTM menu bar.
 * Twin calibration (6DOF): 
 
 Twin calibration (6DOF)
-* Make sure that the Euler Angles definition setting in the QTM project is set to
+* Make sure that the Euler Angles definition setting in the QTM Project Options is set to
     "Qualisys standard".
 * Create a single rigid body with two sets of markers that are visible to the respective
-    systems.
+    systems (master and slave systems).
 * Create a single rigid body definition including both sets of markers.
 * Split the rigid body definition into two separate ones, for example by exporting and
-    editing the XML and loading it to QTM again. This way, two rigid body definitions are
+    editing the XML and loading it into QTM again. This way, two rigid body definitions are
     created with a common origin and orientation.
     Note: Both rigid bodies should use global coordinates.
 * Do a twin measurement with the rigid body in a central location in both volumes. Merge
@@ -28,7 +28,7 @@ Twin calibration (6DOF)
 * In QTM Project Options, fill in the twin calibration parameters as a manual calibration in
     the twin calibration dialog and reprocess the file with the updated twin calibration.
 * Make sure that the rigid body data is the same in the frame that was used for the
-    calibration and not too different in the rest of the measurement. If so, use the twin
+    calibration and not too different in the rest of the measurement. If ok, use the twin
     calibration for subsequent measurements.
 
 Requirements:
@@ -140,8 +140,10 @@ def _twin_calib_6dof():
     tp = [D[0], D[1], D[2], \
             RPYs[0], RPYs[1], RPYs[2]]
 
-    trm.write("Twin calibration parameters (X, Y, Z, Roll, Pitch, Yaw): ")
-    print(f'{tp[0]:.3f}, {tp[1]:.3f}, {tp[2]:.3f}, {tp[3]:.3f}, {tp[4]:.3f}, {tp[5]:.3f}')
+    trm.write(f"\n--- Twin calibration (6DOF) ---")
+    trm.write(f"Twin System calibration parameters (X, Y, Z, Roll, Pitch, Yaw): ")
+    trm.write(f"{tp[0]:.3f}, {tp[1]:.3f}, {tp[2]:.3f}, {tp[3]:.3f}, {tp[4]:.3f}, {tp[5]:.3f}\n\n")
+    trm.write(f"Fill in as 'Manual Calibration' in the twin calibration dialog.")
 
 
 def add_my_commands():
@@ -168,7 +170,7 @@ def setup_my_menu():
     # Add button for updating Refine rigid body menu items.
     qtm.gui.insert_menu_button(my_menu_id, "Twin calibration (6DOF)", "twin_calib_6dof")
 
-# menu_priority = 1
+menu_priority = 1
 
 def add_menu():
     if have_numpy:


### PR DESCRIPTION
# Description
Twin tools adds a menu *Twin* containing tools for twin system users. Currently, it contains one tool for obtaining twin calibration parameters using a rigid body.

# Use case
Alternative twin calibration method for applications in which it is difficult to perform the twin wand calibration.

# Testing
Tested with twin measurements with an underwater and above water system. Tested for a variety of calibrations (different alignments of coordinate systems) and rigid body poses.