### PR TITLE
Fix sys.path Initialization for tools and user directories in startup_demo_scripts.py

### DIFF
--- a/startup_tools.py
+++ b/startup_tools.py
@@ -1,6 +1,7 @@
 """
 Startup for tool menus. Invoke the add_menu function for scripts found at the top level of the tools folder.
 """
+from json import tool
 import sys
 import os
 import inspect
@@ -12,8 +13,12 @@ this_file = inspect.getfile(inspect.currentframe())
 this_dir = os.path.dirname(os.path.abspath(this_file))
 if this_dir not in sys.path:
     sys.path.append(this_dir)
-    sys.path.append(os.path.join(this_dir,"tools"))
-    sys.path.append(os.path.join(this_dir,"user"))
+tools_dir = os.path.join(this_dir, "tools")
+if tools_dir not in sys.path:
+    sys.path.append(tools_dir)
+user_dir = os.path.join(this_dir, "user")
+if user_dir not in sys.path:
+    sys.path.append(user_dir)
 
 # NOTE ON ADDING NEW MENU FILES
 #


### PR DESCRIPTION
## Summary
This pull request aims to address a bug where the tools and user directories was not being correctly added to sys.path if startup_demo_scripts.py had already been loaded once. The PR ensures that both the tools and user directories are correctly added to sys.path during startup.

## Changes
Added explicit checks for the directories before adding them.
## Testing
[x] Loads in QTM without problem
[x] User and Tools are added to path

## Related Issues
Fixes #2 