### PR TITLE
Demo Scripts Dependent On 'helpers', Duplicate 'helpers' Into 'demo_scripts'

### DIFF
--- a/demo_scripts/helpers/matrix.py
+++ b/demo_scripts/helpers/matrix.py
@@ -1,0 +1,192 @@
+import math
+
+
+# - - - - - - - - - - - - - - - - - - -  - - - - - -
+# ////////   E X P O R T E D   C L A S S   ////////
+# - - - - - - - - - - - - - - - - - - - - - - - -
+class Mat4x4:
+    # - - - - - - - - - - - - - - - - - - -
+    # ////////   P R I V A T E   ////////
+    # - - - - - - - - - - - - - - - - -
+    # region [ COLLAPSE / EXPAND ]
+    def __init__(self, *args):
+        self._values = [[0]*4 for _ in range(4)]
+        # Empty (default constructor)
+        if len(args) == 0:
+            # Already initialized so just return
+            return
+        # List of four lists
+        elif len(args) == 1:
+            if not isinstance(args[0], list):
+                raise ValueError("Expected a list but received type '" + str(type(args[0])).split("'", 2)[1] + "'.")
+            if len(args[0]) != 4:
+                raise ValueError("Expected a list with length 4 but received a list with length '" + str(len(args[0])) + "'.")
+            for curr_row in range(len(args[0])):  # AKA: 'curr_list'
+                if not isinstance(args[0][curr_row], list):
+                    raise TypeError("Expected list of lists but object at index '" + str(curr_row) + "' is of type '" + str(type(args[0][curr_row])).split("'", 2)[1] + "'.")
+                if len(args[0][curr_row]) != 4:
+                    raise ValueError("Expected list at index '" + str(curr_row) + "' to have a length of 4 but its length is '" + str(len(args[0][curr_row])) + "'.")
+                for curr_col in range(len(args[0][curr_row])):
+                    if not isinstance(args[0][curr_row][curr_col], (float, int)):
+                        raise TypeError("Expected list of lists to contain only ints or floats but list at index '" + str(curr_row) + "' contains type '" + str(type(args[0][curr_row][curr_col]).split("'", 2)[1]) + "' at index '" + str(curr_col) + "'.")
+                    else:
+                        self._values[curr_row][curr_col] = args[0][curr_row][curr_col]
+        # Four lists
+        elif len(args) == 4:
+            for curr_row in range(len(args)):
+                if not isinstance(args[curr_row], list):
+                    raise TypeError("Expected 4 lists but argument number '" + str(curr_row+1) + "' is of type '" + str(type(args[curr_row])).split("'", 2)[1] + "'.")
+                if len(args[curr_row]) != 4:
+                    raise ValueError("Expected each list to have a length of 4 but list number '" + str(curr_row+1) + "' has a length of '" + str(len(args[0][curr_row])) + "'.")
+                for curr_col in range(len(args[curr_row])):
+                    if not isinstance(args[curr_row][curr_col], (float, int)):
+                        raise TypeError("Expected all lists to contain only ints or floats but list number '" + str(curr_row+1) + "' contains type '" + str(type(args[curr_row][curr_col]).split("'", 2)[1]) + "' at index '" + str(curr_col) + "'.")
+                    else:
+                        self._values[curr_row][curr_col] = args[curr_row][curr_col]
+        # Sixteen ints or floats
+        elif len(args) == 16:
+            curr_arg_index = 0
+            for curr_row in range(4):
+                for curr_col in range(4):
+                    if not isinstance(args[curr_arg_index], (float, int)):
+                        raise TypeError("Expected 16 ints or floats but argument number '" + str(curr_arg_index+1) + "' is of type '" + str(type(args[curr_arg_index]).split("'", 2)[1]) + "'.")
+                    else:
+                        self._values[curr_row][curr_col] = args[curr_arg_index]
+                        curr_arg_index += 1
+        else:
+            exception_str = "Unsupported construction of type '" + self.__class__.__name__ + "' using '" + str(len(args)) + "' argument(s):"
+            for i in range(len(args)):
+                if i != 0:
+                    exception_str += ","
+                exception_str += (" '" + str(type(args[i])).split("'", 2)[1] + "'")
+            raise AttributeError(exception_str)
+
+    def __getitem__(self, key):
+        return self._values[key]
+
+    def __setitem__(self, key, value):
+        if not isinstance(key, int):
+            raise TypeError("Indexing using type '" + str(type(key)).split("'", 2)[1] + "' is not supported.")
+        if not isinstance(value, list):
+            raise TypeError("Inserting a value of type '" + str(type(value)).split("'", 2)[1] + "' is not supported.")
+        if len(value) != 4:
+            raise ValueError("Expected a list with length 4 but received a list with length '" + str(len(value)) + "'.")
+        for i in range(4):
+            if not isinstance(value[i], (float, int)):
+                raise TypeError("Expected list to contain only ints or floats but found type '" + str(type(value[i]).split("'", 2)[1]) + "' at index '" + str(i) + "'.")
+        self._values[key] = value
+
+    def __str__(self):
+        return str(self._values)
+
+    def __iter__(self):
+        # NOTE: This is equivalent to a '__list__' overload
+        return iter(self._values)
+
+    def __add__(self, other):
+        if isinstance(other, self.__class__):
+            return_matrix = [[0]*4 for _ in range(4)]
+            for curr_row in range(4):
+                for curr_col in range(4):
+                    return_matrix[curr_row][curr_col] = self._values[curr_row][curr_col] + other._values[curr_row][curr_col]
+            return self.__class__(return_matrix)
+        else:
+            raise TypeError("Addition to a 4x4 matrix with type '" + str(type(other)).split("'", 2)[1] + "' is not supported.")
+
+    def __iadd__(self, other):
+        return self.__add__(other)
+
+    def __sub__(self, other):
+        if isinstance(other, self.__class__):
+            return_matrix = [[0]*4 for _ in range(4)]
+            for curr_row in range(4):
+                for curr_col in range(4):
+                    return_matrix[curr_row][curr_col] = self._values[curr_row][curr_col] - other._values[curr_row][curr_col]
+            return self.__class__(return_matrix)
+        else:
+            raise TypeError("Subtraction from a 4x4 matrix with type '" + str(type(other)).split("'", 2)[1] + "' is not supported.")
+
+    def __isub__(self, other):
+        return self.__sub__(other)
+
+    def __mul__(self, other):
+        if isinstance(other, self.__class__):
+            return_matrix = [[0]*4 for _ in range(4)]
+            for curr_row in range(4):
+                for curr_col in range(4):
+                    for section in range(4):
+                        return_matrix[curr_row][curr_col] += self._values[curr_row][section] * other._values[section][curr_col]
+            return self.__class__(return_matrix)
+        else:
+            raise TypeError("Multiplication between left-side operand 4x4 matrix and right-side operand type '" + str(type(other)).split("'", 2)[1] + "' is not supported.")
+
+    def __imul__(self, other):
+        return self.__mul__(other)
+
+    def __rmul__(self, other):
+        # NOTE: Mathematically, Scalar*Mat4x4 is an acceptable operation. However,
+        #       the operation is not defined in Python, so we need to check for it.
+        if (isinstance(other, (int, float))):
+            return_matrix = [[0]*4 for _ in range(4)]
+            for curr_row in range(4):
+                for curr_col in range(4):
+                    return_matrix[curr_row][curr_col] = self._values[curr_row][curr_col] * other
+            return self.__class__(return_matrix)
+        else:
+            return other.__mul__(self)
+
+    def __eq__(self, other):
+        if isinstance(other, self.__class__):
+            for curr_row in range(4):
+                for curr_col in range(4):
+                    if self._values[curr_row][curr_col] != other._values[curr_row][curr_col]:
+                        return False
+            return True
+        else:
+            raise TypeError("Comparing type '" + self.__class__.__name__ + "' with type '" + str(type(other)).split("'", 2)[1] + "' is not supported.")
+    # endregion
+
+    # - - - - - - - - - - - - - - - - - -
+    # ////////   P U B L I C   ////////
+    # - - - - - - - - - - - - - - - -
+    # region [ COLLAPSE / EXPAND ]
+    @classmethod
+    def create_identity_matrix(self):
+        return Mat4x4([
+            [1, 0, 0, 0],
+            [0, 1, 0, 0],
+            [0, 0, 1, 0],
+            [0, 0, 0, 1]
+        ])
+
+    @classmethod
+    def create_translation_matrix(self, translation_vec):
+        return Mat4x4([
+            [1.0, 0.0, 0.0, translation_vec[0]],
+            [0.0, 1.0, 0.0, translation_vec[1]],
+            [0.0, 0.0, 1.0, translation_vec[2]],
+            [0.0, 0.0, 0.0, 1.0]
+        ])
+
+    @classmethod
+    def create_rotation_matrix(self, radians_rot_x, radians_rot_y, radians_rot_z):
+        matrix_rot_x = Mat4x4([
+            [1, 0,                       0,                        0],
+            [0, math.cos(radians_rot_x), -math.sin(radians_rot_x), 0],
+            [0, math.sin(radians_rot_x), math.cos(radians_rot_x),  0],
+            [0, 0,                       0,                        1]
+        ])
+        matrix_rot_y = Mat4x4([
+            [math.cos(radians_rot_y),  0, math.sin(radians_rot_y), 0],
+            [0,                        1, 0,                       0],
+            [-math.sin(radians_rot_y), 0, math.cos(radians_rot_y), 0],
+            [0,                        0, 0,                       1]
+        ])
+        matrix_rot_z = Mat4x4([
+            [math.cos(radians_rot_z), -math.sin(radians_rot_z), 0, 0],
+            [math.sin(radians_rot_z), math.cos(radians_rot_z),  0, 0],
+            [0,                       0,                        1, 0],
+            [0,                       0,                        0, 1]
+        ])
+        return ((matrix_rot_x * matrix_rot_y) * matrix_rot_z)
+    # endregion

--- a/demo_scripts/helpers/menu_tools.py
+++ b/demo_scripts/helpers/menu_tools.py
@@ -1,0 +1,157 @@
+import sys
+import os
+import inspect
+this_dir = os.path.dirname(os.path.abspath(inspect.getfile(inspect.currentframe())))
+if this_dir not in sys.path:
+    sys.path.append(this_dir)
+    
+from vector import Vec3
+import printing as printing
+import qtm
+
+# variables
+_toggle_button_menu_ids = {}
+
+
+# - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+# ////////   P R I V A T E   F U N C T I O N S   ////////
+# - - - - - - - - - - - - - - - - - - - - - - - - - - -
+# region [ COLLAPSE / EXPAND ]
+def _look_for_duplicate_button_texts_and_print_warning(menu_id, list_of_menu_items_as_dicts, button_text_state_one, button_text_state_two):
+    for menu_item_as_dict in list_of_menu_items_as_dicts:
+        found_text = ""
+        if menu_item_as_dict["text"] == button_text_state_one:
+            found_text = button_text_state_one
+        elif menu_item_as_dict["text"] == button_text_state_two:
+            found_text = button_text_state_two
+        if found_text != "":
+            comment_str = "Duplicate button text '" + found_text + "' found in menu '" + str(menu_id) + "'(ID)."
+            comment_suggestion = "For toggleable buttons to work properly, all buttons in that menu/submenu must have unique names."
+            printing.force_print("WARNING", comment_str, comment_suggestion, only_filename=True)
+            break
+
+
+def _find_menu_button_in_submenus_and_toggle_it(menu_id, button_text_state_one, button_text_state_two, toggle_command):
+    child_submenu_ids = []
+    list_of_all_menu_items_as_dicts = qtm.gui.get_menu_items(menu_id)
+    menu_button_found = False
+    # Loop through all items
+    for i in range(len(list_of_all_menu_items_as_dicts)):
+        # Check if item is a submenu child
+        if list_of_all_menu_items_as_dicts[i]["submenu"] != 0:
+            child_submenu_ids.append(list_of_all_menu_items_as_dicts[i]["submenu"])
+        else:
+            if list_of_all_menu_items_as_dicts[i]["text"] == button_text_state_one:
+                # Successful match with 'button_text_state_one' text
+                qtm.gui.delete_menu_item(menu_id, i)
+                add_menu_item(menu_id, button_text_state_two, toggle_command, i)
+                menu_button_found = True
+                _look_for_duplicate_button_texts_and_print_warning(menu_id, list_of_all_menu_items_as_dicts[i+1:], button_text_state_two, button_text_state_one)
+                break
+            elif list_of_all_menu_items_as_dicts[i]["text"] == button_text_state_two:
+                # Successful match with 'button_text_state_two' text
+                qtm.gui.delete_menu_item(menu_id, i)
+                add_menu_item(menu_id, button_text_state_one, toggle_command, i)
+                menu_button_found = True
+                _look_for_duplicate_button_texts_and_print_warning(menu_id, list_of_all_menu_items_as_dicts[i+1:], button_text_state_two, button_text_state_one)
+                break
+    if menu_button_found is False:
+        # No matches found ==> Recursive search (one for each additional child submenu)
+        for id in child_submenu_ids:
+            menu_button_found = _find_menu_button_in_submenus_and_toggle_it(id, button_text_state_one, button_text_state_two, toggle_command)
+            if menu_button_found is True:
+                # A match was found ==> break recursion
+                break
+    return menu_button_found
+
+
+def _toggle_menu_button(menu_id, button_text_state_one, button_text_state_two, toggle_command, action_command):
+    list_of_all_menu_items_as_dicts = qtm.gui.get_menu_items(menu_id)
+    menu_button_found = False
+    # Search through the 'top-layer' of menu items
+    for i in range(len(list_of_all_menu_items_as_dicts)):
+        if list_of_all_menu_items_as_dicts[i]["text"] == button_text_state_one:
+            # Successful match with 'button_text_state_one' text
+            qtm.gui.delete_menu_item(menu_id, i)
+            add_menu_item(menu_id, button_text_state_two, toggle_command, i)
+            menu_button_found = True
+            _look_for_duplicate_button_texts_and_print_warning(menu_id, list_of_all_menu_items_as_dicts[i+1:], button_text_state_one, button_text_state_one)
+            break
+        elif list_of_all_menu_items_as_dicts[i]["text"] == button_text_state_two:
+            # Successful match with 'button_text_state_two' text
+            qtm.gui.delete_menu_item(menu_id, i)
+            add_menu_item(menu_id, button_text_state_one, toggle_command, i)
+            menu_button_found = True
+            _look_for_duplicate_button_texts_and_print_warning(menu_id, list_of_all_menu_items_as_dicts[i+1:], button_text_state_two, button_text_state_one)
+            break
+    if menu_button_found is False:
+        # No matches found ==> Begin recursive search through this menu's submenus
+        menu_button_found = _find_menu_button_in_submenus_and_toggle_it(menu_id, button_text_state_one, button_text_state_two, toggle_command)
+    if menu_button_found is False:
+        comment_str = "Toggle button '" + button_text_state_one + " / " + button_text_state_two + "' was not found."
+        suggestion_str = "This might be due to the button's original text not matching the text expected by '_toggle_menu_button'."
+        printing.force_print("WARNING", comment_str, suggestion_str, only_filename=True)
+    # Call the ACTUAL command (irregardless if button-text toggling worked correctly)
+    qtm.gui.send_command(action_command)
+#endregion
+
+
+# - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+# ////////   E X P O R T E D   F U N C T I O N S   ////////
+# - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+# region [ COLLAPSE / EXPAND ]
+def clamp(value, lower, upper):
+    return min(max(lower, value), upper)
+
+
+def calculate_acceleration(p1, p2, p3, dt):
+    return (Vec3(p3) - (Vec3(p2) * 2) + Vec3(p1)) / (dt * dt)
+
+
+def set_command_hotkey(ctrl_modifier, alt_modifier, shift_modifier, key, command_name):
+    qtm.gui.set_accelerator({"ctrl": ctrl_modifier, "alt": alt_modifier, "shift": shift_modifier, "key": key}, command_name)
+
+
+def set_toggleable_command_hotkey(ctrl_modifier, alt_modifier, shift_modifier, key, command_name):
+    set_command_hotkey(ctrl_modifier, alt_modifier, shift_modifier, key, str(command_name + "_internal"))
+
+
+def add_command(name, execute_func, update_func=None):
+    if name in qtm.gui.get_commands():
+        return False  # E A R L Y   E X I T
+    qtm.gui.add_command(name)
+    qtm.gui.set_command_execute_function(name, execute_func)
+    if update_func is not None:
+        qtm.gui.set_command_update_function(name, update_func)
+    return True
+
+
+def add_menu_item(menu_id, button_text, command_name, index=None):
+    # Get menu name
+    list_of_all_menus_as_dicts = qtm.gui.get_menu_items()
+    menu_name = ""
+    for curr_menu in list_of_all_menus_as_dicts:
+        if curr_menu["submenu"] == menu_id:
+            menu_name = curr_menu["text"].replace("&", "")
+    # Check for duplicate button-text in submenu
+    list_of_all_menu_items_as_dicts = qtm.gui.get_menu_items(menu_id)
+    for curr_item in list_of_all_menu_items_as_dicts:
+        if curr_item["text"] == button_text:
+            comment_str = str("Tried to add item to menu '" + menu_name + "' (ID: " + str(menu_id) + ") using existing button text '" + button_text + "'.")
+            suggestion_str = "For toggleable buttons to work, all button texts (in a specific menu / submenu) must be unique."
+            printing.force_print("ERROR", comment_str, suggestion_str)
+            return False  # E A R L Y   E X I T
+    qtm.gui.insert_menu_button(menu_id, button_text, command_name, index)
+    return True
+
+
+def add_menu_item_toggleable(menu_id, button_text_state_one, button_text_state_two, command_name, index=None):
+    # Generate command-name that toggles the button (also calls the ACTUAL command)
+    toggle_command_name = str(command_name + "_internal")
+    if toggle_command_name not in globals()["_toggle_button_menu_ids"]:
+        # This is the first time creating this toggle, so we add the command
+        add_command(toggle_command_name, lambda: (_toggle_menu_button(globals()["_toggle_button_menu_ids"][toggle_command_name], button_text_state_one, button_text_state_two, toggle_command_name, command_name)))
+    # Update (or add, if first time) 'toggle_command_name' & menu ID key-value pair
+    globals()["_toggle_button_menu_ids"][toggle_command_name] = menu_id
+    add_menu_item(globals()["_toggle_button_menu_ids"][toggle_command_name], button_text_state_one, toggle_command_name, index)
+# endregion

--- a/demo_scripts/helpers/printing.py
+++ b/demo_scripts/helpers/printing.py
@@ -1,0 +1,230 @@
+import sys
+import inspect
+import os
+import datetime
+import traceback
+
+this_dir = os.path.dirname(os.path.abspath(inspect.getfile(inspect.currentframe())))
+if this_dir not in sys.path:
+    sys.path.append(this_dir)
+
+import menu_tools as tools
+
+
+# constants
+_error_print_periodicity = 2.0  # As seconds
+_error_signatures_stack_size = 32
+# variables
+_prev_error_signatures = [""] * _error_signatures_stack_size
+_prev_error_index = 0
+_prev_time = datetime.datetime.now()
+_accumulated_dt = 0.0
+
+
+# - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+# ////////   P R I V A T E   F U N C T I O N S   ////////
+# - - - - - - - - - - - - - - - - - - - - - - - - - - -
+# region [ COLLAPSE / EXPAND ]
+def _try_print(signature, title, func_name, line_num, filename, comment, suggestion, call_stack):
+    if _signatures_stack_has_signature(signature) is False:
+        # New error ==> PRINT
+        _insert_error_signature(signature)
+        print(_create_print_message(title, func_name, line_num, filename, comment, suggestion, call_stack))
+        # Reset time-variables here to avoid inconsistent printing
+        globals()['_prev_time'] = datetime.datetime.now()
+        globals()['_accumulated_dt'] = 0
+    else:
+        # Error already reported ==> adjust time-variables
+        curr_time = datetime.datetime.now()
+        dt = curr_time - globals()['_prev_time']
+        globals()['_accumulated_dt'] += dt.total_seconds()
+        globals()['_prev_time'] = curr_time
+        # Timer has passed 'print periodicity' ==> PRINT
+        if globals()['_accumulated_dt'] > globals()['_error_print_periodicity']:
+            _insert_error_signature(signature)
+            print(_create_print_message(title, func_name, line_num, filename, comment, suggestion, call_stack))
+            # Reset accumulated time
+            globals()['_accumulated_dt'] = 0
+
+
+def _create_print_message(title, func_name, line_num, filename, comment, suggestion, call_stack):
+    result = ""
+    result += ("\n" + title[:7] + "\t|FUNCTION NAME: " + func_name)
+    result += (" (line " + line_num + " in '" + filename + "')")
+    if comment != "":
+        result += "\n"
+        result += "-" * len(title[:7])
+        result += ("\t|COMMENT:" + "\t" + comment)
+    if suggestion != "":
+        result += ("\n\t|SUGGESTION: " + "\t" + suggestion)
+    if call_stack != "":
+        result += ("\n" + call_stack)
+    return result
+
+
+def _signatures_stack_has_signature(signature):
+    if signature in globals()['_prev_error_signatures']:
+        return True
+    return False
+
+
+def _insert_error_signature(signature):
+    curr_error_index = globals()['_prev_error_index'] + 1
+    if curr_error_index == globals()['_error_signatures_stack_size']:
+        curr_error_index = 0
+    globals()['_prev_error_signatures'][curr_error_index] = signature
+    globals()['_prev_error_index'] = curr_error_index
+
+
+def _traceback_list_to_array(traceback_list):
+    return_array = [[0]*4 for i in range(len(traceback_list))]
+    for i in range(len(traceback_list)):
+        temp_string = traceback_list[i]
+        # Filepath
+        temp_string = temp_string.split("\"", 2)
+        return_array[i][1] = temp_string[1]
+        # Line number
+        temp_string = temp_string[2].split("line ", 1)[1].split(",", 1)
+        return_array[i][2] = temp_string[0]
+        # Function name
+        temp_string = temp_string[1].split("in ", 1)[1].split("\n", 1)
+        return_array[i][3] = temp_string[0]
+        # The actual line of code
+        return_array[i][0] = temp_string[1].lstrip()
+    return return_array
+
+
+def _get_call_stack_as_str(call_stack_2d_array, prune_depth, reverse_order=False):
+    prune_depth = tools.clamp(prune_depth, 0, len(call_stack_2d_array))
+    return_str = "\tCALL STACK:"
+    if (prune_depth == len(call_stack_2d_array)):
+        return ""  # E A R L Y   E X I T
+    else:
+        total_depth = len(call_stack_2d_array)
+        curr_depth = 0
+        # Remove 'prune_depth' number of entries, bot -> top
+        for i in range(total_depth - prune_depth):
+            if reverse_order:
+                index = total_depth-i-1
+            else:
+                index = i
+            return_str += ("\n\t\t")
+            if (i != 0):
+                return_str += (" "*(curr_depth-1) + "\\" + " ")
+            return_str += call_stack_2d_array[index][3]
+            return_str += " (line "
+            return_str += str(call_stack_2d_array[index][2])
+            return_str += " in "
+            return_str += os.path.basename(call_stack_2d_array[index][1])
+            return_str += ")"
+            curr_depth += 1
+    return return_str
+
+
+def _get_call_stack_exception_last_layer():
+    return_array = [0]*4
+    traceback_as_2d_array = _traceback_list_to_array(traceback.extract_tb(sys.exc_info()[2]).format())
+    last_index = len(traceback_as_2d_array) - 1
+    for i in range(4):
+        return_array[i] = traceback_as_2d_array[last_index][i]
+    return return_array
+
+
+def _get_call_stack_exception(prune_depth=0):
+    traceback_as_2d_array = _traceback_list_to_array(traceback.extract_tb(sys.exc_info()[2]).format())
+    return _get_call_stack_as_str(traceback_as_2d_array, prune_depth)
+# endregion
+
+
+# - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+# ////////   E X P O R T E D   F U N C T I O N S   ////////
+# - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+# region [ COLLAPSE / EXPAND ]
+def get_this_method_name():
+    return inspect.stack()[1][3]
+
+
+def get_parent_method_name():
+    try:
+        inspect.stack()[2][3]
+    except IndexError as e:
+        try_print_except(str(e), "The parent method wasn't found. Perhaps the function calling this passed as a lambda?")
+        return "Parent method not found!"
+    return inspect.stack()[2][3]
+
+
+def get_this_method_line_num():
+    return inspect.stack()[1][2]
+
+
+def get_parent_method_line_num():
+    try:
+        inspect.stack()[2][2]
+    except IndexError as e:
+        try_print_except(str(e), "The parent method wasn't found. Perhaps the function calling this was passed as a lambda?")
+        return "Parent method not found!"
+    return inspect.stack()[2][2]
+
+
+def get_this_method_filename():
+    return inspect.stack()[1][1]
+
+
+def get_parent_method_filename():
+    try:
+        inspect.stack()[2][2]
+    except IndexError as e:
+        try_print_except(str(e), "The parent method wasn't found. Perhaps the function calling this was passed as a lambda?")
+        return "Parent method not found!"
+    return inspect.stack()[2][1]
+
+
+def try_print_except(comment="", suggestion="", only_filename=False):
+    # Append the exception type to the comment
+    comment = str(sys.exc_info()[0]).split("'", 2)[1] + " - " + comment
+    call_stack_bot_layer_info = _get_call_stack_exception_last_layer()
+    func_name = call_stack_bot_layer_info[3]
+    line_num = call_stack_bot_layer_info[2]
+    if only_filename:
+        filename = call_stack_bot_layer_info[1].rsplit("\\", 1)[1]
+    else:
+        filename = call_stack_bot_layer_info[1]
+    call_stack = _get_call_stack_exception()
+    signature = func_name + line_num
+    _try_print(signature, "EXCEPT", func_name, line_num, filename, comment, suggestion, call_stack)
+
+
+def force_print_except(comment="", suggestion="", only_filename=False):
+    # Append the exception type to the comment
+    comment = str(sys.exc_info()[0]).split("'", 2)[1] + " - " + comment
+    call_stack_bot_layer_info = _get_call_stack_exception_last_layer()
+    func_name = call_stack_bot_layer_info[3]
+    line_num = call_stack_bot_layer_info[2]
+    if only_filename:
+        filename = call_stack_bot_layer_info[1].rsplit("\\", 1)[1]
+    else:
+        filename = call_stack_bot_layer_info[1]
+    call_stack = _get_call_stack_exception()
+    print(_create_print_message("EXCEPT", func_name, line_num, filename, comment, suggestion, call_stack))
+
+
+def try_print(title_short="MSG", comment="", suggestion="", only_filename=False):
+    func_name = get_parent_method_name()
+    line_num = str(get_parent_method_line_num())
+    if only_filename:
+        filename = get_parent_method_filename().rsplit("\\", 1)[1]
+    else:
+        filename = get_parent_method_filename()
+    signature = func_name + line_num
+    _try_print(signature, title_short, func_name, line_num, filename, comment, suggestion, "")
+
+
+def force_print(title_short, comment="", suggestion="", only_filename=False):
+    func_name = get_parent_method_name()
+    line_num = str(get_parent_method_line_num())
+    if only_filename:
+        filename = get_parent_method_filename().rsplit("\\", 1)[1]
+    else:
+        filename = get_parent_method_filename()
+    print(_create_print_message(title_short, func_name, line_num, filename, comment, suggestion, ""))
+# endregion

--- a/demo_scripts/helpers/selection.py
+++ b/demo_scripts/helpers/selection.py
@@ -1,0 +1,33 @@
+import traj
+import sys
+import qtm
+
+
+# - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+# ////////   E X P O R T E D   F U N C T I O N S   ////////
+# - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+# region [ COLLAPSE / EXPAND ]
+def get_selected_marker_ids():
+    selections = qtm.gui.selection.get_selections()
+    return [selection["id"] for selection in selections if selection["type"] == "trajectory"]
+
+
+def get_selected_bone_ids():
+    selections = qtm.gui.selection.get_selections()
+    return [selection["id"] for selection in selections if selection["type"] == "bone"]
+
+
+def select_all_trajectories():
+    selections = [{"type": "trajectory", "id": id} for id in qtm.data.series._3d.get_series_ids()]
+    qtm.gui.selection.set_selections(selections)
+
+
+def select_labeled_trajectories():
+    selections = [{"type": "trajectory", "id": id} for id in traj.get_labeled_marker_ids()]
+    qtm.gui.selection.set_selections(selections)
+
+
+def select_unlabeled_trajectories():
+    selections = [{"type": "trajectory", "id": id} for id in traj.get_unlabeled_marker_ids()]
+    qtm.gui.selection.set_selections(selections)
+# endregion

--- a/demo_scripts/helpers/traj.py
+++ b/demo_scripts/helpers/traj.py
@@ -1,0 +1,222 @@
+from vector import Vec3
+import menu_tools as tools
+import qtm
+
+
+
+# - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+# ////////   P R I V A T E   F U N C T I O N S   ////////
+# - - - - - - - - - - - - - - - - - - - - - - - - - - -
+# region [ COLLAPSE / EXPAND ]
+def _calc_marker_speed(id, sample_index, dt):
+    sample_prev = None
+    sample_next = None
+    sample_curr = qtm.data.series._3d.get_sample(id, sample_index)
+
+    if sample_curr is None:
+        return 0  # E A R L Y   E X I T
+
+    if sample_index != 0:
+        sample_prev = qtm.data.series._3d.get_sample(id, sample_index - 1)
+    if sample_index != qtm.data.series._3d.get_sample_range(id)['end']:
+        sample_next = qtm.data.series._3d.get_sample(id, sample_index + 1)
+
+    if sample_prev is None and sample_next is None:
+        return 0  # E A R L Y   E X I T
+
+    position_curr = sample_curr["position"]
+    velocity_prev = [0.0, 0.0, 0.0]
+    velocity_next = [0.0, 0.0, 0.0]
+    speed_prev = 0
+    speed_next = 0
+
+    if sample_prev:
+        position_prev = sample_prev["position"]
+        velocity_prev = Vec3(position_curr) - Vec3(position_prev)
+        speed_prev = velocity_prev.magnitude() / dt
+    if sample_next:
+        position_next = sample_next["position"]
+        velocity_next = Vec3(position_next) - Vec3(position_curr)
+        speed_next = velocity_next.magnitude() / dt
+
+    if sample_prev is not None and sample_next is not None:
+        return ((speed_prev + speed_next) * 0.5)
+    elif sample_prev is not None:
+        return speed_prev
+    else:
+        return speed_next
+
+
+def _calc_marker_acceleration(id, sample_index, dt):
+    sample_prev = None
+    sample_next = None
+    sample_curr = None
+    sample_curr = qtm.data.series._3d.get_sample(id, sample_index)
+
+    if sample_curr is None:
+        return 0  # E A R L Y   E X I T
+
+    if sample_index != 0:
+        sample_prev = qtm.data.series._3d.get_sample(id, sample_index - 1)
+    else:
+        sample_prev = sample_curr
+    if sample_index != qtm.data.series._3d.get_sample_range(id)['end']:
+        sample_next = qtm.data.series._3d.get_sample(id, sample_index + 1)
+    else:
+        sample_next = sample_curr
+    if sample_prev is None or sample_next is None:
+        return 0  # E A R L Y   E X I T
+
+    p1 = sample_curr["position"]
+    p2 = sample_curr["position"]
+    p3 = sample_curr["position"]
+
+    if sample_index != 0:
+        p1 = sample_prev["position"]
+    if sample_index != qtm.data.series._3d.get_sample_range(id)['end']:
+        p3 = sample_next["position"]
+
+    return tools.calculate_acceleration(p1, p2, p3, dt).magnitude()
+# endregion
+
+
+# - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+# ////////   E X P O R T E D   F U N C T I O N S   ////////
+# - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+# region [ COLLAPSE / EXPAND ]
+def get_marker_counts_three():
+    total_count = 0
+    labeled_count = 0
+    unlabeled_count = 0
+
+    all_traj_ids = qtm.data.series._3d.get_series_ids()
+    for id in all_traj_ids:
+        total_count += 1
+        if qtm.data.object.trajectory.get_label(id) is not None:
+            labeled_count += 1
+
+    unlabeled_count = total_count - labeled_count
+    return (total_count, labeled_count, unlabeled_count)
+
+
+def get_labeled_marker_ids():
+    all_traj_ids = qtm.data.series._3d.get_series_ids()
+    return [id for id in all_traj_ids if qtm.data.object.trajectory.get_label(id) is not None]
+
+
+def get_unlabeled_marker_ids():
+    all_traj_ids = qtm.data.series._3d.get_series_ids()
+    return [id for id in all_traj_ids if qtm.data.object.trajectory.get_label(id) is None]
+
+
+def get_marker_positions(measurement_time, marker_ids, include_none_values=False):
+    return_list = []
+    for id in marker_ids:
+        index = qtm.data.series._3d.get_sample_index_at_time(id, measurement_time)
+        curr_marker = qtm.data.series._3d.get_sample(id, index)
+        if curr_marker != None:
+            return_list.append(curr_marker["position"])
+        elif include_none_values:
+            return_list.append(None)
+    return return_list
+
+
+def calc_avg_residual(list_of_marker_ids, measurement_time):
+    if len(list_of_marker_ids) == 0:
+        return 0  # E A R L Y   E X I T
+
+    sum_of_residuals = 0
+
+    for id in list_of_marker_ids:
+        sample_index = qtm.data.series._3d.get_sample_index_at_time(id, measurement_time)
+        curr_traj_curr_sample_data = qtm.data.series._3d.get_sample(id, sample_index)
+        if curr_traj_curr_sample_data is not None:
+            sum_of_residuals += curr_traj_curr_sample_data['residual']
+
+    return (sum_of_residuals / len(list_of_marker_ids))
+
+
+def calc_avg_speed(list_of_marker_ids, measurement_time):
+    if len(list_of_marker_ids) == 0:
+        return 0  # E A R L Y   E X I T
+
+    sum_of_speeds = 0
+
+    for id in list_of_marker_ids:
+        sample_index = qtm.data.series._3d.get_sample_index_at_time(id, measurement_time)
+        # Freq is reciprocal of dt
+        dt = 1.0 / qtm.data.series._3d.get_frequency(id)
+        # Convert millimeters to meters
+        sum_of_speeds += _calc_marker_speed(id, sample_index, dt) / 1000.0
+
+    return (sum_of_speeds / len(list_of_marker_ids))
+
+
+def calc_avg_acceleration(list_of_marker_ids, measurement_time):
+    if len(list_of_marker_ids) == 0:
+        return 0  # E A R L Y   E X I T
+
+    sum_of_accelerations = 0
+
+    for id in list_of_marker_ids:
+        sample_index = qtm.data.series._3d.get_sample_index_at_time(id, measurement_time)
+        # Freq is reciprocal of dt
+        dt = 1.0 / qtm.data.series._3d.get_frequency(id)
+        # Convert millimeters to meters
+        sum_of_accelerations += _calc_marker_acceleration(id, sample_index, dt) / 1000.0
+
+    return (sum_of_accelerations / len(list_of_marker_ids))
+
+def get_selected_markerset_marker(noisy = False):
+    """
+    Convenience function to return the currently selected marker and its
+    markerset.
+    """
+    if qtm.gui.selection.get_selection_count() == 0:
+        if noisy:
+            print(f"Select a marker in the markerset.")
+        return None, None
+    selections = qtm.gui.selection.get_selections()
+    s = selections[0]
+    id = s["id"]
+    try:
+        fullname = qtm.data.object.trajectory.get_label(id)
+    except:
+        return None,None
+
+    if not fullname:
+        print(f"An unnamed marker is selected.")
+        return None, None
+    if not "_" in fullname:
+        print(f"Selected marker is not in a markerset.")
+        return None, None
+    s = fullname.split("_",1)
+    markersetname = s[0]
+    markername = s[1]
+
+    return markersetname, markername
+
+def get_default_markerset_marker():
+    """
+    Return the selected marker and markerset.  If one isn't
+    selected, find the first marker in a markerset and return
+    that one.
+    """
+    markerset, marker = get_selected_markerset_marker()
+    if markerset:
+        return markerset, marker
+    try:
+        seriesIDs = qtm.data.series._3d.get_series_ids()
+    except:
+        print(f"No measurement")
+        return None, None
+
+    for id in seriesIDs:
+        fullname = qtm.data.object.trajectory.get_label(id)
+        if fullname:
+            if "_" in fullname:
+                s = fullname.split("_",1)
+                return s[0], s[1]
+    return None, None
+
+# endregion

--- a/demo_scripts/helpers/vector.py
+++ b/demo_scripts/helpers/vector.py
@@ -1,0 +1,165 @@
+import math
+
+
+# - - - - - - - - - - - - - - - - - - -  - - - - - -
+# ////////   E X P O R T E D   C L A S S   ////////
+# - - - - - - - - - - - - - - - - - - - - - - - -
+class Vec3:
+    # - - - - - - - - - - - - - - - - - - -
+    # ////////   P R I V A T E   ////////
+    # - - - - - - - - - - - - - - - - -
+    # region [ COLLAPSE / EXPAND ]
+    def __init__(self, *args):
+        # Empty (default constructor)
+        if len(args) == 0:
+            self._x = 0.0
+            self._y = 0.0
+            self._z = 0.0
+        # List of ints or floats
+        elif len(args) == 1:
+            if not isinstance(args[0], list):
+                raise ValueError("Expected a list but received type '" + str(type(args[0])).split("'", 2)[1] + "'.")
+            if len(args[0]) != 3:
+                raise ValueError("Expected a list with length 3 but received a list with length '" + str(len(args[0])) + "'.")
+            if (isinstance(args[0][0], (float, int)) and isinstance(args[0][1], (float, int)) and isinstance(args[0][2], (float, int))):
+                self._x = args[0][0]
+                self._y = args[0][1]
+                self._z = args[0][2]
+            else:
+                exception_str = "Unsupported construction of type '" + self.__class__.__name__ + "'."
+                exception_str += " Expected three floats or integers but received:"
+                exception_str += " '" + str(args[0][0]) + "', '" + str(args[0][1]) + "', '" + str(args[0][2]) + "'"
+                raise ValueError(exception_str)
+        # Three ints or floats
+        elif len(args) == 3:
+            if (isinstance(args[0], (float, int)) and isinstance(args[1], (float, int)) and isinstance(args[2], (float, int))):
+                self._x = args[0]
+                self._y = args[1]
+                self._z = args[2]
+            else:
+                exception_str = "Unsupported construction of type '" + self.__class__.__name__ + "'."
+                exception_str += " Expected three floats or integers but received:"
+                exception_str += " '" + str(args[0]) + "', '" + str(args[1]) + "', '" + str(args[2]) + "'"
+                raise ValueError(exception_str)
+        else:
+            exception_str = "Unsupported construction of type '" + self.__class__.__name__ + "' using '" + str(len(args)) + "' argument(s):"
+            for i in range(len(args)):
+                if i != 0:
+                    exception_str += ","
+                exception_str += (" '" + str(type(args[i])).split("'", 2)[1] + "'")
+            raise AttributeError(exception_str)
+
+    def __getitem__(self, key):
+        if isinstance(key, int):
+            # NOTE: Default Python behaviour allows indexing with negative numbers
+            if (key < 0):
+                key %= 3
+            if key == 0:
+                return self._x
+            elif key == 1:
+                return self._y
+            elif key == 2:
+                return self._z
+            else:  # Index larger than 2
+                raise IndexError("Incorrect index value " + str(key) + " provided. Index cannot be larger than 2.")
+        else:
+            raise TypeError("Indexing using type '" + str(type(key)).split("'", 2)[1] + "' is not supported.")
+
+    def __setitem__(self, key, value):
+        if not isinstance(key, int):
+            raise TypeError("Indexing using type '" + str(type(key)).split("'", 2)[1] + "' is not supported.")
+        if not isinstance(value, (int, float)):
+            raise ValueError("Inserting a value of type '" + str(type(value)).split("'", 2)[1] + "' is not supported.")
+        # NOTE: Default Python behaviour allows indexing with negative numbers
+        if (key < 0):
+            key %= 3
+        if key == 0:
+            self._x = value
+        elif key == 1:
+            self._y = value
+        elif key == 2:
+            self._z = value
+        else:
+            raise IndexError("Incorrect index value " + str(key) + " provided. Index must be 0, 1, or 2.")
+
+    def __str__(self):
+        return f"[{self._x}, {self._y}, {self._z}]"
+
+    def __iter__(self):
+        # NOTE: This is equivalent to a '__list__' overload
+        return iter([self._x, self._y, self._z])
+
+    def __add__(self, other):
+        if isinstance(other, self.__class__):
+            return self.__class__(self._x + other._x, self._y + other._y, self._z + other._z)
+        else:
+            raise TypeError("Addition to a vector with type '" + str(type(other)).split("'", 2)[1] + "' is not supported.")
+
+    def __iadd__(self, other):
+        return self.__add__(other)
+
+    def __sub__(self, other):
+        if isinstance(other, self.__class__):
+            return self.__class__(self._x - other._x, self._y - other._y, self._z - other._z)
+        else:
+            raise TypeError("Subtraction from a vector with type '" + str(type(other)).split("'", 2)[1] + "' is not supported.")
+
+    def __isub__(self, other):
+        return self.__sub__(other)
+
+    def __mul__(self, other):
+        if isinstance(other, self.__class__):
+            return (self._x * other._x + self._y * other._y + self._z * other._z)
+        elif isinstance(other, (int, float)):
+            return self.__class__(self._x * other, self._y * other, self._z * other)
+        else:
+            raise TypeError("Multiplication between a vector and type '" + str(type(other)).split("'", 2)[1] + "' is not supported.")
+
+    def __imul__(self, other):
+        return self.__mul__(other)
+
+    def __rmul__(self, other):
+        # NOTE: Mathematically, Vec3*Scalar produces the same result as Scalar*Vec3.
+        #       However, the operation is not defined in Python, so we need to check for it.
+        if (isinstance(other, (int, float))):
+            return self.__mul__(other)
+        else:
+            return other.__mul__(self)  # Attempt reverse multiplication
+
+    def __truediv__(self, other):
+        if isinstance(other, (int, float)):
+            return self.__class__(self._x / other, self._y / other, self._z / other)
+        elif isinstance(other, self.__class__):
+            raise TypeError("Dividing a vector by another vector is not mathematically possible.")
+        else:
+            raise TypeError("Dividing a vector with type '" + str(type(other)).split("'", 2)[1] + "' is not supported.")
+
+    def __itruediv__(self, other):
+        return self.__truediv__(other)
+
+    def __eq__(self, other):
+        if isinstance(other, self.__class__):
+            if (self._x == other._x and self._y == other._y and self._z == other._z):
+                return True
+            else:
+                return False
+        else:
+            raise TypeError("Comparing type '" + self.__class__.__name__ + "' with type '" + str(type(other)).split("'", 2)[1] + "' is not supported.")
+    # endregion
+
+    # - - - - - - - - - - - - - - - - - -
+    # ////////   P U B L I C   ////////
+    # - - - - - - - - - - - - - - - -
+    # region [ COLLAPSE / EXPAND ]
+    def cross(self, other):
+        if isinstance(other, Vec3):
+            return_vec_x = ((self._y * other._z) - (self._z * other._y))
+            return_vec_y = ((self._z * other._x) - (self._x * other._z))
+            return_vec_z = ((self._x * other._y) - (self._y * other._x))
+            return Vec3(return_vec_x, return_vec_y, return_vec_z)
+        else:
+            raise TypeError("Vector cross product with type '" + str(type(other)).split("'", 2)[1] + "' is not supported.")
+
+    def magnitude(self):
+        return math.sqrt(self.__mul__(self))
+    # endregion


### PR DESCRIPTION
Currently, simply copying the 'demo_scripts' folder and trying to run 'startup.py' in there doesn't work out of the box, which one might expect it to do. This is because the 'helpers' is required, and has since then been moved out into the parent directory. This 'helpers' folder is also used by other scripts, for example in scripts contained in the 'tools' folder, so moving it back is not an option.

I like having 'demo_scripts' be a stand-alone & runnable set of examples, but I also don't necessarily like the solution of duplicating 'demo_scripts'. I also don't hate this solution. Either way, I'm open to suggestions / other opinions.

- **EDIT:** I received some feedback that the 'helpers' folder is kept separate from the 'demo_scripts' to allow users to download the repository and access both 'demo_scripts' and 'tools' via load functions. This setup works fine as far as the demo scripts are concerned.
The reason I raised this as a concern is whether the demo scripts need to be standalone for easier access. I attempted to run the demo scripts as is, and ran into the missing 'helpers' folder, but this could very well be a non-issue that users will not encounter. Note that if users encounter this error they should easily be able to resolve it based on the error message provided.
It's very likely that this is unnecessary, in which case I'll just close this pull request, but I felt like I should at least lift the conversation.

- **EDIT 2:** Upon further consideration, I'm leaning more towards not duplicating 'helpers', and instead see if there's some way we can produce a warning if users attempt to run the 'startup.py' directly from 'demo_scripts'.