### PR TITLE
Fixed 'Delete Button' Message For Menu Dividers / Separators

### DIFF
--- a/demo_scripts/Classes/custom_menu_bar_class.py
+++ b/demo_scripts/Classes/custom_menu_bar_class.py
@@ -79,7 +79,10 @@ class custom_menu_bar:
         list_of_all_menus_as_dicts = qtm.gui.get_menu_items()
         for curr_menu in list_of_all_menus_as_dicts:
             if curr_menu["submenu"] == self._menu_id:
-                print("\n" + "The '" + qtm.gui.get_menu_item(curr_menu["submenu"], 0)["text"] + "' button was successfully removed.")
+                if qtm.gui.get_menu_item(curr_menu["submenu"], 0)["text"] == "" and qtm.gui.get_menu_item(curr_menu["submenu"], 0)["command"] == "":
+                    print("\n" + "A menu divider / separator line was successfully removed.")
+                else:
+                    print("\n" + "The '" + qtm.gui.get_menu_item(curr_menu["submenu"], 0)["text"] + "' button was successfully removed.")
                 qtm.gui.delete_menu_item(self._menu_id, 0)
                 break
 


### PR DESCRIPTION
When pressing the 'Delete Button' menu item, if it deleted a menu divider / separator, the message was simply incorrect (_see images below_). This has now been fixed.

![image](https://github.com/qualisys/qtm-scripting/assets/32294492/72d2fb37-f421-48d0-9d0d-fcea93d98a31)

**BEFORE:**
![image](https://github.com/qualisys/qtm-scripting/assets/32294492/8392dcca-d72f-4560-b5a4-c5573fbdc012)

**AFTER:**
![image](https://github.com/qualisys/qtm-scripting/assets/32294492/d74b21fc-ee98-441f-ad44-5c020acbc139)