### PR TITLE
Teapot Mesh New Scale Value

### DIFF
--- a/demo_scripts/Classes/custom_3d_scene_class.py
+++ b/demo_scripts/Classes/custom_3d_scene_class.py
@@ -158,7 +158,7 @@ class custom_3d_scene:
         # NOTE: The order of which the translation & rotation matrices are multiplied matters
         tran_rot_matrix = translation_matrix * rotation_matrix
         # Load the 'utah-teapot.obj' mesh, scaled by the given ratio
-        qtm.gui._3d.draw_mesh(list(tran_rot_matrix), 1.5, "utah-teapot.obj")
+        qtm.gui._3d.draw_mesh(list(tran_rot_matrix), 0.1, "utah-teapot.obj")
     # endregion
 
     # - - - - - - - - - - - - - - - - - -


### PR DESCRIPTION
Apparently something happened recently with how QTM renders meshes, which caused the teapot mesh to become massive with the current scale value. This PR adjusts the scale value from 1.5 to 0.1.

BEFORE:
![image](https://github.com/qualisys/qtm-scripting/assets/32294492/44958b37-5c76-4188-8521-775d10d223f1)

AFTER:
![image](https://github.com/qualisys/qtm-scripting/assets/32294492/d8174e3f-c899-4c71-b661-49973784150d)