### PR TITLE
Warning Comments For Using Variables In Helper Modules

### DIFF
--- a/helpers/matrix.py
+++ b/helpers/matrix.py
@@ -1,5 +1,8 @@
 import math
 
+# variables
+# WARNING: Adding variables here is potentially dangerous; variables are reset each time a script loads this module
+
 
 # - - - - - - - - - - - - - - - - - - -  - - - - - -
 # ////////   E X P O R T E D   C L A S S   ////////

--- a/helpers/menu_tools.py
+++ b/helpers/menu_tools.py
@@ -10,7 +10,7 @@ import printing as printing
 import qtm
 
 # variables
-_toggle_button_menu_ids = {}
+# WARNING: Adding variables here is potentially dangerous; variables are reset each time a script loads this module
 
 
 # - - - - - - - - - - - - - - - - - - - - - - - - - - - - -

--- a/helpers/printing.py
+++ b/helpers/printing.py
@@ -15,6 +15,7 @@ import menu_tools as tools
 _error_print_periodicity = 2.0  # As seconds
 _error_signatures_stack_size = 32
 # variables
+# WARNING: Adding variables here is potentially dangerous; variables are reset each time a script loads this module
 _prev_error_signatures = [""] * _error_signatures_stack_size
 _prev_error_index = 0
 _prev_time = datetime.datetime.now()

--- a/helpers/selection.py
+++ b/helpers/selection.py
@@ -2,6 +2,9 @@ import traj
 import sys
 import qtm
 
+# variables
+# WARNING: Adding variables here is potentially dangerous; variables are reset each time a script loads this module
+
 
 # - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 # ////////   E X P O R T E D   F U N C T I O N S   ////////

--- a/helpers/traj.py
+++ b/helpers/traj.py
@@ -2,6 +2,8 @@ from vector import Vec3
 import menu_tools as tools
 import qtm
 
+# variables
+# WARNING: Adding variables here is potentially dangerous; variables are reset each time a script loads this module
 
 
 # - - - - - - - - - - - - - - - - - - - - - - - - - - - - -

--- a/helpers/vector.py
+++ b/helpers/vector.py
@@ -1,5 +1,8 @@
 import math
 
+# variables
+# WARNING: Adding variables here is potentially dangerous; variables are reset each time a script loads this module
+
 
 # - - - - - - - - - - - - - - - - - - -  - - - - - -
 # ////////   E X P O R T E D   C L A S S   ////////


### PR DESCRIPTION
We ran into a bug caused by the fact that, when running multiple scripts simultaneously (_that load helper modules_), the variables in these modules gets reset each time it's loaded. To avoid possible confusion and bugs, this PR adds short warning messages to these helper modules as a precaution.